### PR TITLE
CI: Fix the coverage reports artifacts not being uploaded

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,8 @@ jobs:
           # File renamed for thix matrix element
           name: coverage-${{ matrix.pixi_environment }}-${{ matrix.os }}
           path: .coverage.${{ matrix.pixi_environment }}-${{ matrix.os }}
+          include-hidden-files: true
+          if-no-files-found: error
 
   merge-coverage:
     name: Merge the coverage reports from multiple coverages


### PR DESCRIPTION
The upload-artifacts action won't upload hidden files by default anymore.
This forces the inclusion of hidden files as it is required by merge-coverage and triggers an error when no coverage report file is found.

[related issue on coverage-comment-action](https://github.com/py-cov-action/python-coverage-comment-action/issues/473)